### PR TITLE
Show dropdown of type in editor

### DIFF
--- a/app/assets/stylesheets/administrate-field-json/editor.css
+++ b/app/assets/stylesheets/administrate-field-json/editor.css
@@ -2,6 +2,10 @@
   display: none;
 }
 
+table.jsoneditor-tree td {
+  overflow: visible;
+}
+
 table.jsoneditor-search input {
   padding: 0;
   line-height: 20px; 


### PR DESCRIPTION
This was needed to have the editor css play nicely with the styles in Administrate. The global `td` style in administra has the `overflow` attribute set to `hidden`. This changes that and shows the dropdown menu again when clicking in the jsoneditor.

![screenshot 2016-05-11 11 53 16](https://cloud.githubusercontent.com/assets/5436814/15177351/d48dfbe2-176f-11e6-88e8-ab15ce1932f0.png)
