### PR TITLE
Add base assets to precompilation

### DIFF
--- a/app/views/fields/json/_form.html.erb
+++ b/app/views/fields/json/_form.html.erb
@@ -14,8 +14,8 @@ This partial renders an JSON database into structured form
 
 %>
 <% content_for :javascript, flush: true do %> 
-<%= javascript_include_tag '/assets/administrate-field-json.js' %>
-<%= stylesheet_link_tag '/assets/administrate-field-json.css' %>
+<%= javascript_include_tag 'administrate-field-json.js' %>
+<%= stylesheet_link_tag 'administrate-field-json.css' %>
 <% end %>
 
 

--- a/lib/administrate/field/json.rb
+++ b/lib/administrate/field/json.rb
@@ -16,8 +16,8 @@ module Administrate
           Rails.application.config.assets.paths << engine_root.join("app", "assets", "javascripts", "administrate-field-json")
           Rails.application.config.assets.paths << engine_root.join("app", "assets", "stylesheets", "administrate-field-json")
           Rails.application.config.assets.paths << engine_root.join("vendor", "assets", "images")
+          Rails.application.config.assets.precompile += ['administrate-field-json.js','administrate-field-json.css']
         end
-        
       end
     end
   end


### PR DESCRIPTION
Since administrate adds the `.svg` to the precompilation path: https://github.com/thoughtbot/administrate/blob/master/lib/administrate/engine.rb#L23
What was missing to have `rake assets:precompile` work with the needed `.js` and `.css` was this line. I could have chosen to add `*.js` or the like instead of full filename, but then it would precompile files that were not needed in the end (since they're referenced in these base files).
