### PR TITLE
Add support for Rails 5.

### DIFF
--- a/administrate-field-json.gemspec
+++ b/administrate-field-json.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", "~> 0.2.2"
-  gem.add_dependency "rails", "~> 4.2"
+  gem.add_dependency "administrate", "~> 0.3"
+  gem.add_dependency "rails", ">= 4.2", "< 5.1"
 end

--- a/administrate-field-json.gemspec
+++ b/administrate-field-json.gemspec
@@ -1,10 +1,8 @@
 $:.push File.expand_path("../lib", __FILE__)
 
-require "administrate/field/json"
-
 Gem::Specification.new do |gem|
   gem.name = "administrate-field-json"
-  gem.version = Administrate::Field::JSON::VERSION
+  gem.version = "0.0.3"
   gem.authors = ["Eddie A Tejeda"]
   gem.email = ["eddie@codeforamerica.org"]
   gem.homepage = "https://github.com/eddietejeda/administrate-field-json"

--- a/lib/administrate/field/json.rb
+++ b/lib/administrate/field/json.rb
@@ -6,8 +6,6 @@ require "administrate/engine"
 module Administrate
   module Field
     class JSON < Administrate::Field::Base
-      VERSION = "0.0.3"
-
       class Engine < ::Rails::Engine
         Administrate::Engine.add_javascript "administrate-field-json/application"
         Administrate::Engine.add_stylesheet "administrate-field-json/application"


### PR DESCRIPTION
This shifts the dependencies to support Rails 5 and fixes up a circular dependency issue. It seems to work fine with Rails 5 (with limited testing).

Closes #9, #10.