### PR TITLE
allow vertical resize of jsoneditor box when in text mode

### DIFF
--- a/app/assets/stylesheets/administrate-field-json/editor.css
+++ b/app/assets/stylesheets/administrate-field-json/editor.css
@@ -12,5 +12,9 @@ table.jsoneditor-tree td {
 
 table.jsoneditor-search input {
   padding: 0;
-  line-height: 20px; 
+  line-height: 20px;
+}
+
+textarea.jsoneditor-text {
+  resize: vertical;
 }


### PR DESCRIPTION
There's currently no way to adjust the height of the json-editor box in text mode. This adds an resize feature that allows for vertical expansion like so:

![image](https://user-images.githubusercontent.com/1256329/28241125-3b8c9742-695c-11e7-85e5-24818c33e1e2.png)
